### PR TITLE
Adds support for blacklisting JWT refresh token on logout

### DIFF
--- a/angular.json
+++ b/angular.json
@@ -103,5 +103,8 @@
         }
       }
     }
+  },
+  "cli": {
+    "analytics": false
   }
 }

--- a/src/app/authentication/components/login/login.component.ts
+++ b/src/app/authentication/components/login/login.component.ts
@@ -29,9 +29,13 @@ export class LoginComponent implements OnInit {
    */
   onSubmit(): void {
     this.apiService.login(this.username, this.password).subscribe({
-      next: () => {this.handleSuccessfulLogin()},
-      error: () => {this.handleUnsuccessfulLogin()}
-    })
+      next: () => {
+        this.handleSuccessfulLogin();
+      },
+      error: () => {
+        this.handleUnsuccessfulLogin();
+      }
+    });
   }
 
   /**

--- a/src/app/authentication/components/logout/logout.component.html
+++ b/src/app/authentication/components/logout/logout.component.html
@@ -1,1 +1,1 @@
-<p>You have been logged out.</p>
+<p>{{ statusText }}</p>

--- a/src/app/authentication/components/logout/logout.component.ts
+++ b/src/app/authentication/components/logout/logout.component.ts
@@ -6,7 +6,7 @@ import { ApiService } from "../../../common/services/api.service";
   standalone: true,
   templateUrl: 'logout.component.html',
 })
-export class LogoutComponent implements OnInit{
+export class LogoutComponent implements OnInit {
 
   constructor(private apiService: ApiService) {}
 
@@ -14,7 +14,7 @@ export class LogoutComponent implements OnInit{
    * Automatically log the user out on page loa
    */
   ngOnInit(): void {
-    this.apiService.logout()
+    this.apiService.logout().subscribe();
   }
 
 }

--- a/src/app/authentication/components/logout/logout.component.ts
+++ b/src/app/authentication/components/logout/logout.component.ts
@@ -7,14 +7,19 @@ import { ApiService } from "../../../common/services/api.service";
   templateUrl: 'logout.component.html',
 })
 export class LogoutComponent implements OnInit {
+  statusText = 'You are being logged out...';
 
   constructor(private apiService: ApiService) {}
 
   /**
-   * Automatically log the user out on page loa
+   * Automatically log the user out on page load
    */
   ngOnInit(): void {
-    this.apiService.logout().subscribe();
+    this.apiService.logout().subscribe({
+      next: () => {
+        this.statusText = 'You have been successfully logged out.';
+      }
+    });
   }
 
 }

--- a/src/app/authentication/guards/authGuard.ts
+++ b/src/app/authentication/guards/authGuard.ts
@@ -3,7 +3,7 @@ import { Router } from '@angular/router';
 import { ApiService } from '../../common/services/api.service';
 
 export const authGuard = () => {
-    const apiService = inject(ApiService);
-    const router = inject(Router);
-    return apiService.isAuthenticated() || router.parseUrl('/auth/login');
-}
+  const apiService = inject(ApiService);
+  const router = inject(Router);
+  return apiService.isAuthenticated() || router.parseUrl('/auth/login');
+};

--- a/src/app/common/services/api.service.ts
+++ b/src/app/common/services/api.service.ts
@@ -15,8 +15,7 @@ export class ApiService {
   private refreshEndpoint: URL = new URL('authentication/refresh/', this.apiURL);
   private blacklistEndpoint: URL = new URL('authentication/blacklist/', this.apiURL);
 
-  constructor(private http: HttpClient) {
-  }
+  constructor(private http: HttpClient) {}
 
   /**
    * Get the current JWT access token.
@@ -103,8 +102,7 @@ export class ApiService {
    */
   public logout(): Observable<void> {
     return this.http.post(this.blacklistEndpoint.href, {refresh: this.refreshToken}).pipe(
-      map(() => {
-      }),
+      map(() => {}),
       finalize(() => {
         this.clearTokens();
       })

--- a/src/app/common/services/api.service.ts
+++ b/src/app/common/services/api.service.ts
@@ -2,7 +2,7 @@ import { Injectable } from '@angular/core';
 import { HttpClient, HttpHeaders } from '@angular/common/http';
 
 import { jwtDecode } from "jwt-decode";
-import { catchError, finalize, map, Observable, of, throwError } from 'rxjs';
+import { finalize, map, Observable, of } from 'rxjs';
 
 import { environment } from '../../../environments/environment';
 
@@ -93,7 +93,8 @@ export class ApiService {
         map((response: any) => {
           this.accessToken = response.access;
           this.refreshToken = response.refresh;
-        }));
+        })
+      );
   }
 
   /**
@@ -194,7 +195,6 @@ export class ApiService {
     const refreshHeaders = new HttpHeaders({'Content-Type': 'application/json'});
     this.http.post(this.refreshEndpoint.href, {refresh: this.refreshToken}, {headers: refreshHeaders}).subscribe({
       next: (response: any) => {
-        console.log('updating tokens');
         this.accessToken = response.access;
       },
       error: () => {

--- a/src/app/common/services/api.service.ts
+++ b/src/app/common/services/api.service.ts
@@ -2,7 +2,7 @@ import { Injectable } from '@angular/core';
 import { HttpClient, HttpHeaders } from '@angular/common/http';
 
 import { jwtDecode } from "jwt-decode";
-import { finalize, map, Observable } from 'rxjs';
+import { catchError, finalize, map, Observable, of, throwError } from 'rxjs';
 
 import { environment } from '../../../environments/environment';
 
@@ -101,6 +101,10 @@ export class ApiService {
    * @returns An observable of the logout request
    */
   public logout(): Observable<void> {
+    if (!this.isAuthenticated()) {
+      return of(void 0);
+    }
+
     return this.http.post(this.blacklistEndpoint.href, {refresh: this.refreshToken}).pipe(
       map(() => {}),
       finalize(() => {

--- a/src/app/common/services/api.service.ts
+++ b/src/app/common/services/api.service.ts
@@ -1,8 +1,10 @@
 import { Injectable } from '@angular/core';
 import { HttpClient, HttpHeaders } from '@angular/common/http';
-import { map, Observable } from 'rxjs';
-import { environment } from '../../../environments/environment';
+
 import { jwtDecode } from "jwt-decode";
+import { catchError, map, Observable } from 'rxjs';
+
+import { environment } from '../../../environments/environment';
 
 @Injectable({
   providedIn: 'root'
@@ -11,16 +13,72 @@ export class ApiService {
   private apiURL: URL = new URL(environment.apiURL);
   private authEndpoint: URL = new URL('authentication/new/', this.apiURL);
   private refreshEndpoint: URL = new URL('authentication/refresh/', this.apiURL);
+  private blacklistEndpoint: URL = new URL('authentication/blacklist/', this.apiURL);
 
   constructor(private http: HttpClient) {}
 
   /**
-   * Check if the current API session is authenticated.
-   * @returns true if the user is authenticated, false otherwise
+   * Get the current JWT access token.
+   * @returns The access token if available, otherwise null
    */
-  public isAuthenticated(): boolean {
-    this.refreshAuthToken();
-    return !!localStorage.getItem('accessToken');
+  private get accessToken(): string | null {
+    return localStorage.getItem('accessToken');
+  }
+
+  /**
+   * Set the JWT access token.
+   * @param token The access token value
+   */
+  private set accessToken(token: string) {
+    localStorage.setItem('accessToken', token);
+  }
+
+  /**
+   * Get the expiration time of the JWT access token.
+   * @returns The expiration time of the access token if available, otherwise null
+   */
+  private get accessTokenExpiration(): number | null {
+    if (this.accessToken) {
+      return <number>jwtDecode(this.accessToken).exp * 1000;
+    } else {
+      return null;
+    }
+  }
+
+  /**
+   * Get the current JWT refresh token.
+   * @returns The refresh token if available, otherwise null
+   */
+  private get refreshToken(): string | null {
+    return localStorage.getItem('refreshToken');
+  }
+
+  /**
+   * Set the JWT refresh token.
+   * @param token The refresh token value
+   */
+  private set refreshToken(token: string) {
+    localStorage.setItem('refreshToken', token);
+  }
+
+  /**
+   * Get the expiration time of the refresh token.
+   * @returns The expiration time of the refresh token if available, otherwise null
+   */
+  private get refreshTokenExpiration(): number | null {
+    if (this.refreshToken) {
+      return <number>jwtDecode(this.refreshToken).exp * 1000;
+    } else {
+      return null;
+    }
+  }
+
+  /**
+   * Delete all JWT token data.
+   */
+  private clearTokens(): void {
+    localStorage.removeItem('accessToken');
+    localStorage.removeItem('refreshToken');
   }
 
   /**
@@ -29,22 +87,30 @@ export class ApiService {
    * @param password The password
    * @returns An observable of the login request
    */
-  public login(username: string, password: string): Observable<any> {
+  public login(username: string, password: string): Observable<void> {
     return this.http.post(this.authEndpoint.href, {'username': username, 'password': password})
       .pipe(
         map((response: any) => {
-            localStorage.setItem('accessToken', response.access);
-            localStorage.setItem('refreshToken', response.refresh);
-          }
-        ));
+          this.accessToken = response.access;
+          this.refreshToken = response.refresh;
+        }));
   }
 
   /**
-   * Log out the current API session.
+   * Log out the current API session and clear any token data.
    */
-  public logout(): void {
-    localStorage.removeItem('accessToken');
-    localStorage.removeItem('refreshToken');
+  public logout(): Observable<void> {
+    this.clearTokens();
+    return this.http.post(this.blacklistEndpoint.href, {refresh: this.refreshToken});
+  }
+
+  /**
+   * Check if the current API session is authenticated.
+   * @returns true if the user is authenticated, false otherwise
+   */
+  public isAuthenticated(): boolean {
+    this.refreshAuthTokens();
+    return !!this.refreshToken;
   }
 
   /**
@@ -53,7 +119,7 @@ export class ApiService {
    * @returns An observable of the request
    */
   public get(endpoint: string): Observable<object> {
-    this.refreshAuthToken();
+    this.refreshAuthTokens();
     const url = new URL(endpoint, this.apiURL);
     return this.http.get(url.href, {headers: this.getAuthHeaders()});
   }
@@ -65,7 +131,7 @@ export class ApiService {
    * @returns An observable of the request
    */
   public post(endpoint: string, data: object): Observable<object> {
-    this.refreshAuthToken();
+    this.refreshAuthTokens();
     const url = new URL(endpoint, this.apiURL);
     return this.http.post(url.href, data,{headers: this.getAuthHeaders()});
   }
@@ -77,7 +143,7 @@ export class ApiService {
    * @returns An observable of the request
    */
   public put(endpoint: string, data: object): Observable<object> {
-    this.refreshAuthToken();
+    this.refreshAuthTokens();
     const url = new URL(endpoint, this.apiURL);
     return this.http.put(url.href, data, {headers: this.getAuthHeaders()});
   }
@@ -89,7 +155,7 @@ export class ApiService {
    * @returns An observable of the request
    */
   public patch(endpoint: string, data: object): Observable<object> {
-    this.refreshAuthToken();
+    this.refreshAuthTokens();
     const url = new URL(endpoint, this.apiURL);
     return this.http.patch(url.href, data, {headers: this.getAuthHeaders()});
   }
@@ -100,7 +166,7 @@ export class ApiService {
    * @returns An observable of the request
    */
   public delete(endpoint: string): Observable<object> {
-    this.refreshAuthToken();
+    this.refreshAuthTokens();
     const url = new URL(endpoint, this.apiURL);
     return this.http.delete(url.href, {headers: this.getAuthHeaders()});
   }
@@ -109,26 +175,20 @@ export class ApiService {
    * Refresh the authentication token if necessary. If the current API session is not authenticated
    * or the authentication token is not expired, this method does nothing.
    */
-  private refreshAuthToken(): void {
-    const accessToken = localStorage.getItem('accessToken');
-    const refreshToken = localStorage.getItem('refreshToken');
-
+  private refreshAuthTokens(): void {
     // Only refresh the token if the user is logged in and the token has expired
-    const now = new Date().getDate()
-    if (!accessToken || now < <number>jwtDecode(accessToken).exp) {
+    if (!this.refreshTokenExpiration || Date.now() < this.refreshTokenExpiration) {
       return;
     }
 
     // If the refresh fails, assume the refresh token is expired and log the user out
     const refreshHeaders = new HttpHeaders({'Content-Type': 'application/json'})
-    this.http.post(this.refreshEndpoint.href, {refresh: refreshToken}, {headers: refreshHeaders}).subscribe({
-      next: (response: any) => {
-        localStorage.setItem('accessToken', response.access);
-      },
-      error: () => {
-        this.logout();
-      }
-    });
+    this.http.post(this.refreshEndpoint.href, {refresh: this.refreshToken}, {headers: refreshHeaders}).pipe(
+        map((response: any) => {
+          this.accessToken = response.access;
+        }),
+        catchError(this.logout)
+    );
   }
 
   /**
@@ -136,11 +196,8 @@ export class ApiService {
    * @returns HttpHeaders containing the authentication token if available
    */
   private getAuthHeaders(): HttpHeaders {
-    const accessToken = localStorage.getItem('accessToken');
-    if (accessToken) {
-      return new HttpHeaders({
-        'Authorization': 'Bearer ' + accessToken
-      });
+    if (this.accessToken) {
+      return new HttpHeaders({'Authorization': 'Bearer ' + this.accessToken});
     } else {
       return new HttpHeaders();
     }


### PR DESCRIPTION
The back end API is adding a `blacklist` endpoint. This PR adds support for blacklisting the refresh token on logout.