### PR TITLE
Adds CI for publishing Docker image on new release tag

### DIFF
--- a/.github/workflows/Publish.yml
+++ b/.github/workflows/Publish.yml
@@ -1,0 +1,64 @@
+name: 🤖 Publish Package
+
+on:
+  workflow_call:
+    inputs:
+      version:
+        description: 'Set the version number of the published application.'
+        default: '0.0.0'
+        required: false
+        type: string
+
+jobs:
+  publish-docker:
+    runs-on: ubuntu-latest
+    name: Docker Image
+
+    steps:
+      - name: Checkout source
+        uses: actions/checkout@v4
+
+      - name: Fetch image artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: keystone-web-docker
+          path: /tmp
+
+      - name: Load image
+        run: docker load --input /tmp/keystone-web.tar
+
+      - name: Define Docker metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ghcr.io/${{ github.repository_owner }}/keystone-web
+          tags: |
+            type=semver,pattern={{version}}
+            type=raw,value=latest
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Publish image
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+
+  trigger-docs:
+    name: Trigger Docs
+    runs-on: ubuntu-latest
+    steps:
+      - name: Update docs
+        uses: pitt-crc/keystone-docs/.github/actions/update-action/@main
+        with:
+          keystone-gitops-id: ${{ secrets.KEYSTONE_GITOPS_ID }}
+          keystone-gitops-pk: ${{ secrets.KEYSTONE_GITOPS_PK }}
+          repo-name: keystone-web
+          tag: v${{ inputs.version }}

--- a/.github/workflows/Release.yml
+++ b/.github/workflows/Release.yml
@@ -1,0 +1,43 @@
+name: 🎯 Release
+
+on:
+  release:
+    types: [ "released" ]
+
+env:
+  IMAGE_NAME: ghcr.io/${{ github.repository_owner }}/keystone-web
+
+jobs:
+  version:
+    name: Get Release Version
+    runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.get_version.outputs.version }}
+
+    steps:
+      - name: Determine version from release tag
+        id: get_version
+        run: |
+          release_tag=${{github.ref}}
+          version="${release_tag#refs/tags/v}"
+          echo "version=$version" >> "$GITHUB_OUTPUT"
+
+  build:
+    name: Build
+    needs: version
+    uses: ./.github/workflows/Build.yml
+    with:
+      version: ${{needs.version.outputs.version}}
+
+  test:
+    name: Test
+    needs: build
+    uses: ./.github/workflows/Test.yml
+
+  publish:
+    name: Publish
+    needs: [ version, test ]
+    uses: ./.github/workflows/Publish.yml
+    secrets: inherit
+    with:
+      version: ${{needs.version.outputs.version}}

--- a/.github/workflows/UpdatedMain.yml
+++ b/.github/workflows/UpdatedMain.yml
@@ -6,7 +6,12 @@ on:
       - main
 
 jobs:
+  build:
+    name: Build
+    uses: ./.github/workflows/Build.yml
+
   qa:
     name: QA
+    needs: build
     uses: ./.github/workflows/QA.yml
     secrets: inherit


### PR DESCRIPTION
This CI follows the same general structure as the keystone-api repo.